### PR TITLE
Disable python build by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set(PROJECT_DESCRIPTION "adaptation for rigid control on flexible devices")
 set(PROJECT_URL https://github.com/${PROJECT_NAMESPACE}/${PROJECT_NAME})
 
 # Project options
-option(BUILD_PYTHON_INTERFACE "Build the python binding" ON)
+option(BUILD_PYTHON_INTERFACE "Build the python binding" OFF)
 option(INSTALL_PYTHON_INTERFACE_ONLY "Instal *ONLY* the python bindings" OFF)
 option(SUFFIX_SO_VERSION "Suffix library name with its version" ON)
 


### PR DESCRIPTION
As discussed with  @nim65s, required to have easier release on ferrum. 