### PR TITLE
package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -19,6 +19,7 @@
   <depend>boost</depend>
   <depend>eigen</depend>
   <depend>eigenpy</depend>
+  <depend>jrl_cmakemodules</depend>
 
   <buildtool_depend>cmake</buildtool_depend>
   <export>


### PR DESCRIPTION
I realized that the jrl-cmakemodules was not part of the package.xml and therefore was not found during a colcon build.

Note: The fetch strategy is not working due to doxygen stuff. Here is the error flagged upon build.
```
Starting >>> flex_joints
--- stderr: flex_joints                              
CMake Warning:
  Manually-specified variables were not used by the project:

    BUILD_PYTHON_BINDINGS


/bin/sh: 1: cd: can't cd to /workspaces/workspace_pal_estimator_ros2/build/flex_joints/_deps/jrl-cmakemodules-build/doc
gmake[3]: *** [_deps/jrl-cmakemodules-build/CMakeFiles/jrl-cmakemodules-doc.dir/build.make:74: _deps/jrl-cmakemodules-build/CMakeFiles/jrl-cmakemodules-doc] Error 2
gmake[2]: *** [CMakeFiles/Makefile2:2569: _deps/jrl-cmakemodules-build/CMakeFiles/jrl-cmakemodules-doc.dir/all] Error 2
gmake[1]: *** [CMakeFiles/Makefile2:2576: _deps/jrl-cmakemodules-build/CMakeFiles/jrl-cmakemodules-doc.dir/rule] Error 2
gmake: *** [Makefile:1352: jrl-cmakemodules-doc] Error 2
CMake Error at _deps/jrl-cmakemodules-build/cmake_install.cmake:70 (file):
  file INSTALL cannot find
  "/workspaces/workspace_pal_estimator_ros2/build/flex_joints/_deps/jrl-cmakemodules-build/doc/doxygen-html":
  No such file or directory.
Call Stack (most recent call first):
  cmake_install.cmake:47 (include)


---
Failed   <<< flex_joints [8.55s, exited with code 1]

Summary: 0 packages finished [8.94s]
  1 package failed: flex_joints
  1 package had stderr output: flex_joints

 *  The terminal process "/usr/bin/bash '-c', '/usr/bin/colcon build --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -DBUILD_PYTHON_BINDINGS=OFF --cmake-force-configure --symlink-install --packages-up-to flex_joints'" terminated with exit code: 1. 
 *  Terminal will be reused by tasks, press any key to close it. 
```